### PR TITLE
Fix Footer Links

### DIFF
--- a/pages/index-new.js
+++ b/pages/index-new.js
@@ -50,7 +50,7 @@ const Parallax = styled.div`
 
   position: relative;
 
-  section {
+  > * {
     position: relative;
     z-index: 1;
   }


### PR DESCRIPTION
The title says it all... not a missing `<a>` but layering.