### PR TITLE
/join + link fixes

### DIFF
--- a/components/ui/MenuBar.js
+++ b/components/ui/MenuBar.js
@@ -18,7 +18,7 @@ const Wrapper = styled.div`
   left: 0;
   background-color: ${props => props.theme.colors.vibrantCream};
   box-shadow: 0 0.2rem 0 ${props => props.theme.colors.black};
-  z-index: 2;
+  z-index: 1000 !important;
 
   ${({ theme }) => theme.bp.mdPlus(' --menu-height: 4rem; ')}
 `

--- a/components/ui/Panel.js
+++ b/components/ui/Panel.js
@@ -10,6 +10,7 @@ const Container = styled.div`
   position: relative;
   display: grid;
   grid-template-columns: 1fr;
+  grid-template-rows: min-content min-content 1fr;
   grid-gap: 2.4rem;
   padding: 2.4rem 2.4rem 3.6rem;
   color: white;

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
 import Head from 'next/head'
 import NextLink from 'next/link'
+import { useRouter } from 'next/router'
 import debounce from 'debounce'
 
 import Public from '../components/layouts/Public'
@@ -86,6 +87,7 @@ const Parallax = styled.div`
 `
 
 const Page = () => {
+  const router = useRouter()
   const section = useRef(null)
   const [availableWidth, setAvailableWidth] = useState(1)
 
@@ -118,10 +120,14 @@ const Page = () => {
       <main>
         <Public>
           <MenuBar>
-            <NextLink href="#join-community">join</NextLink>
-            <NextLink href="https://indiedao.gitbook.io/indiedao/products/lvl-protocol">
+            <NextLink href="/join">join</NextLink>
+            <a
+              href="https://indiedao.gitbook.io/indiedao/products/lvl-protocol"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
               docs
-            </NextLink>
+            </a>
           </MenuBar>
           <PageContent>
             <LevelWindow
@@ -180,12 +186,8 @@ const Page = () => {
                     </Panel>
                     <Panel
                       button={
-                        <Button
-                          onClick={() =>
-                            openUrl('https://forms.gle/BUDbGYTQDBEMCw8dA')
-                          }
-                        >
-                          Join Waitlist
+                        <Button onClick={() => router.push('/join')}>
+                          Mint Now
                         </Button>
                       }
                       smallIllustrationName="Member"
@@ -205,6 +207,10 @@ const Page = () => {
                           along with your growth
                         </li>
                       </ol>
+                      <Body1 color="mutedCream">
+                        Early minting is available and will hold your spot when
+                        lvl is fully integrated with your DAOs.
+                      </Body1>
                     </Panel>
                   </Section>
                   <Section balance="vertical" boundary="some">


### PR DESCRIPTION
This PR includes:

1. a fix to bring the menubar above the content even when built in a different order than in dev/local
2. updated `join` link in menubar
3. updated content for members panel, swapped google form for /join, updated relevant text (see below)

![Screen Shot 2022-02-24 at 10 49 55](https://user-images.githubusercontent.com/38808/155588296-0ee6b60c-96a9-45cd-8365-1e3756d8799d.png)

