### PR TITLE
Fix font spelling and remove unused font.

### DIFF
--- a/components/ui/GlobalStyles.js
+++ b/components/ui/GlobalStyles.js
@@ -36,7 +36,7 @@ const GlobalStyles = createGlobalStyle`
   }
   @font-face {
     font-family: "Geneva";
-    src: url("/fonts/Geneval-Bold-Italic.ttf");
+    src: url("/fonts/Geneva-Bold-Italic.ttf");
     font-style: italic, oblique;
     font-weight: bold;
     font-display: swap;

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -87,12 +87,6 @@ export default class MyDocument extends Document {
             as="font"
             crossOrigin=""
           />
-          <link
-            rel="preload"
-            href="/fonts/Geneva-Regular.ttf"
-            as="font"
-            crossOrigin=""
-          />
           {['16x16', '32x32', '96x96'].map(size => (
             <link
               rel="icon"


### PR DESCRIPTION
Two small issues - 

First was a misspelling of a preloaded font.

The other was a preloaded font that is not used.  Geneva-Regular is not used. We use Geneva-Normal