### PR TITLE
Lock ethers version to v5.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -125,13 +125,13 @@
       "resolved": "https://registry.npmjs.org/@apollo/react-hooks/-/react-hooks-4.0.0.tgz",
       "integrity": "sha512-fCu0cbne3gbUl0QbA8X4L33iuuFVQbC5Jo2MIKRK8CyawR6PoxDpFdFA1kc6033ODZuZZ9Eo4RdeJFlFIIYcLA==",
       "requires": {
-        "@apollo/client": "^3.5.9"
+        "@apollo/client": "^3.5.10"
       },
       "dependencies": {
         "@apollo/client": {
-          "version": "3.5.9",
-          "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.5.9.tgz",
-          "integrity": "sha512-Qq3OE3GpyPG2fYXBzi1n4QXcKZ11c6jHdrXK2Kkn9SD+vUymSrllXsldqnKUK9tslxKqkKzNrkCXkLv7PxwfSQ==",
+          "version": "3.5.10",
+          "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.5.10.tgz",
+          "integrity": "sha512-tL3iSpFe9Oldq7gYikZK1dcYxp1c01nlSwtsMz75382HcI6fvQXyFXUCJTTK3wgO2/ckaBvRGw7VqjFREdVoRw==",
           "requires": {
             "@graphql-typed-document-node/core": "^3.0.0",
             "@wry/context": "^0.6.0",
@@ -154,13 +154,13 @@
       "resolved": "https://registry.npmjs.org/@apollo/react-ssr/-/react-ssr-4.0.0.tgz",
       "integrity": "sha512-IW+x5M6eTTMbKwCfgox+BwfnZVhKTNiAjAHVdeOIc5jHIuG4oyB/gWcEonHRK6RKb+zLV1rOqpdwnJc6wchxLA==",
       "requires": {
-        "@apollo/client": "^3.5.9"
+        "@apollo/client": "^3.5.10"
       },
       "dependencies": {
         "@apollo/client": {
-          "version": "3.5.9",
-          "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.5.9.tgz",
-          "integrity": "sha512-Qq3OE3GpyPG2fYXBzi1n4QXcKZ11c6jHdrXK2Kkn9SD+vUymSrllXsldqnKUK9tslxKqkKzNrkCXkLv7PxwfSQ==",
+          "version": "3.5.10",
+          "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.5.10.tgz",
+          "integrity": "sha512-tL3iSpFe9Oldq7gYikZK1dcYxp1c01nlSwtsMz75382HcI6fvQXyFXUCJTTK3wgO2/ckaBvRGw7VqjFREdVoRw==",
           "requires": {
             "@graphql-typed-document-node/core": "^3.0.0",
             "@wry/context": "^0.6.0",
@@ -17024,32 +17024,6 @@
       "requires": {
         "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
         "ethereumjs-util": "^5.1.1"
-      },
-      "dependencies": {
-        "ethereumjs-abi": {
-          "version": "git+ssh://git@github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0",
-          "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
-          "requires": {
-            "bn.js": "^4.11.8",
-            "ethereumjs-util": "^6.0.0"
-          },
-          "dependencies": {
-            "ethereumjs-util": {
-              "version": "6.2.1",
-              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-              "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
-              "requires": {
-                "@types/bn.js": "^4.11.3",
-                "bn.js": "^4.11.0",
-                "create-hash": "^1.1.2",
-                "elliptic": "^6.5.2",
-                "ethereum-cryptography": "^0.1.3",
-                "ethjs-util": "0.1.6",
-                "rlp": "^2.2.3"
-              }
-            }
-          }
-        }
       }
     },
     "ethashjs": {
@@ -17149,6 +17123,30 @@
         "@ethereum-waffle/mock-contract": "^3.3.0",
         "@ethereum-waffle/provider": "^3.4.0",
         "ethers": "^5.0.1"
+      }
+    },
+    "ethereumjs-abi": {
+      "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0",
+      "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+      "requires": {
+        "bn.js": "^4.11.8",
+        "ethereumjs-util": "^6.0.0"
+      },
+      "dependencies": {
+        "ethereumjs-util": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+          "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
+          "requires": {
+            "@types/bn.js": "^4.11.3",
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "^2.2.3"
+          }
+        }
       }
     },
     "ethereumjs-account": {
@@ -17364,9 +17362,9 @@
       }
     },
     "ethers": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.6.2.tgz",
-      "integrity": "sha512-EzGCbns24/Yluu7+ToWnMca3SXJ1Jk1BvWB7CCmVNxyOeM4LLvw2OLuIHhlkhQk1dtOcj9UMsdkxUh8RiG1dxQ==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.6.1.tgz",
+      "integrity": "sha512-qtl/2W+dwmUa5Z3JqwsbV3JEBZZHNARe5K/A2ePcNAuhJYnEKIgGOT/O9ouPwBijSqVoQnmQMzi5D48LFNOY2A==",
       "requires": {
         "@ethersproject/abi": "5.6.0",
         "@ethersproject/abstract-provider": "5.6.0",
@@ -17375,7 +17373,7 @@
         "@ethersproject/base64": "5.6.0",
         "@ethersproject/basex": "5.6.0",
         "@ethersproject/bignumber": "5.6.0",
-        "@ethersproject/bytes": "5.6.1",
+        "@ethersproject/bytes": "5.6.0",
         "@ethersproject/constants": "5.6.0",
         "@ethersproject/contracts": "5.6.0",
         "@ethersproject/hash": "5.6.0",
@@ -17383,10 +17381,10 @@
         "@ethersproject/json-wallets": "5.6.0",
         "@ethersproject/keccak256": "5.6.0",
         "@ethersproject/logger": "5.6.0",
-        "@ethersproject/networks": "5.6.1",
+        "@ethersproject/networks": "5.6.0",
         "@ethersproject/pbkdf2": "5.6.0",
         "@ethersproject/properties": "5.6.0",
-        "@ethersproject/providers": "5.6.2",
+        "@ethersproject/providers": "5.6.1",
         "@ethersproject/random": "5.6.0",
         "@ethersproject/rlp": "5.6.0",
         "@ethersproject/sha2": "5.6.0",
@@ -17482,9 +17480,9 @@
           }
         },
         "@ethersproject/bytes": {
-          "version": "5.6.1",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.6.1.tgz",
-          "integrity": "sha512-NwQt7cKn5+ZE4uDn+X5RAXLp46E1chXoaMmrxAyA0rblpxz8t58lVkrHXoRIn0lz1joQElQ8410GqhTqMOwc6g==",
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.6.0.tgz",
+          "integrity": "sha512-3hJPlYemb9V4VLfJF5BfN0+55vltPZSHU3QKUyP9M3Y2TcajbiRrz65UG+xVHOzBereB1b9mn7r12o177xgN7w==",
           "requires": {
             "@ethersproject/logger": "^5.6.0"
           }
@@ -17527,9 +17525,9 @@
           "integrity": "sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg=="
         },
         "@ethersproject/networks": {
-          "version": "5.6.1",
-          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.6.1.tgz",
-          "integrity": "sha512-b2rrupf3kCTcc3jr9xOWBuHylSFtbpJf79Ga7QR98ienU2UqGimPGEsYMgbI29KHJfA5Us89XwGVmxrlxmSrMg==",
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.6.0.tgz",
+          "integrity": "sha512-DaVzgyThzHgSDLuURhvkp4oviGoGe9iTZW4jMEORHDRCgSZ9K9THGFKqL+qGXqPAYLEgZTf5z2w56mRrPR1MjQ==",
           "requires": {
             "@ethersproject/logger": "^5.6.0"
           }
@@ -17543,9 +17541,9 @@
           }
         },
         "@ethersproject/providers": {
-          "version": "5.6.2",
-          "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.6.2.tgz",
-          "integrity": "sha512-6/EaFW/hNWz+224FXwl8+HdMRzVHt8DpPmu5MZaIQqx/K/ELnC9eY236SMV7mleCM3NnEArFwcAAxH5kUUgaRg==",
+          "version": "5.6.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.6.1.tgz",
+          "integrity": "sha512-w8Wx15nH+aVDvnoKCyI1f3x0B5idmk/bDJXMEUqCfdO8Eadd0QpDx9lDMTMmenhOmf9vufLJXjpSm24D3ZnVpg==",
           "requires": {
             "@ethersproject/abstract-provider": "^5.6.0",
             "@ethersproject/abstract-signer": "^5.6.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "debounce": "^1.2.1",
     "deepmerge": "^4.2.2",
     "eth-json-rpc-middleware": "^8.0.1",
-    "ethers": "^5.6.1",
+    "ethers": "=5.6.1",
     "graphql": "^15.8.0",
     "graphql-request": "^4.0.0",
     "graphql-tag": "^2.12.6",


### PR DESCRIPTION
On v5.6.2, a bug was introduced producing a RangeError: maximum call stack size exceeded.

Relevant discussion: https://github.com/ethers-io/ethers.js/discussions/2849

Collaborators: @digidigo @mckelvey 

Ticket: https://app.dework.xyz/indiedao/lvl-protocol?taskId=e4cb853b-29c9-4dda-8557-9a924bebed22